### PR TITLE
Add logic control to raw method and tests for corresponding codes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ class Service {
   raw (method, params) {
     if(typeof method === 'undefined') {
       return Promise
-        .reject(new Error('params.method must be defined.'))
+        .reject(errors.MethodNotAllowed('params.method must be defined.'))
         .catch(errorHandler);
     }
 
@@ -133,13 +133,13 @@ function raw (service, method, params) {
 
   if (typeof service.Model[primaryMethod] === 'undefined') {
     return Promise
-      .reject(new Error(`There is no query method ${primaryMethod}.`));
+      .reject(errors.MethodNotAllowed(`There is no query method ${primaryMethod}.`));
   } else if (
     secondaryMethod &&
     typeof service.Model[primaryMethod][secondaryMethod] === 'undefined'
   ) {
     return Promise
-      .reject(new Error(`There is no query method ${primaryMethod}.${secondaryMethod}.`));
+      .reject(errors.MethodNotAllowed(`There is no query method ${primaryMethod}.${secondaryMethod}.`));
   }
 
   return (typeof service.Model[primaryMethod][secondaryMethod] === 'function')

--- a/src/index.js
+++ b/src/index.js
@@ -130,11 +130,14 @@ function raw (service, method, params) {
   // handle client methods like indices.create
   const [meth, ext] = method.split('.');
 
-  if (typeof ext !== 'undefined') {
-    return service.Model[meth][ext](params);
+  if (typeof service.Model[meth] === 'undefined') {
+    return Promise
+      .reject(new Error(`There is no query method ${meth}`));
   }
 
-  return service.Model[meth](params);
+  return (typeof service.Model[meth][ext] === 'function')
+    ? service.Model[meth][ext](params)
+    : service.Model[meth](params);
 }
 
 function find (service, params) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -594,7 +594,16 @@ describe('Elasticsearch Service', () => {
           .catch(err => {
             expect(err.message === 'There is no query method notafunction.');
           });
-      })
+      });
+
+      it('should return a promise when service.method.extention is not a function', () => {
+        app
+          .service('mobiles')
+          .raw('indices.notafunction', {})
+          .catch(err => {
+            expect(err.message === 'There is no query method indices.notafunction.');
+          });
+      });
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -577,6 +577,22 @@ describe('Elasticsearch Service', () => {
             expect(results.test.mappings.mobiles._parent.type).to.equal('people');
           });
       });
+
+      it('should return a promise when the passed in method is not defined', () => {
+        expect(app
+          .service('mobiles')
+          .raw(undefined, {})
+          .catch(err => 'Error is:' + err)
+          .toString() === '[object Promise]');
+      });
+
+      it('should return a promise when service.method is not a function', () => {
+        expect(app
+          .service('mobiles')
+          .raw('notafunction', {})
+          .catch(err => 'Error is:' + err)
+          .toString() === '[object Promise]');
+      })
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -579,19 +579,21 @@ describe('Elasticsearch Service', () => {
       });
 
       it('should return a promise when the passed in method is not defined', () => {
-        expect(app
+        app
           .service('mobiles')
           .raw(undefined, {})
-          .catch(err => 'Error is:' + err)
-          .toString() === '[object Promise]');
+          .catch(err => {
+            expect(err.message === 'params.method must be defined.');
+          });
       });
 
       it('should return a promise when service.method is not a function', () => {
-        expect(app
+        app
           .service('mobiles')
           .raw('notafunction', {})
-          .catch(err => 'Error is:' + err)
-          .toString() === '[object Promise]');
+          .catch(err => {
+            expect(err.message === 'There is no query method notafunction.');
+          });
       })
     });
   });


### PR DESCRIPTION
overview 
---
Make the raw method more stable, and write some tests for it. 

task 
---
- [x] when the query method is not defined, it should return a promise;
- [x] when the query method is not a function, it should return a promise;

issue
---
As I have pointed out, when I 
> git clone
cd feathers-elasticsearch
npm install
npm test

it always fails. I figure out the reason: my machine runs 5.5.1 ES but in test file, api version is set to be 2.4 since my process.env.ES_VERSION is undefined. After I ran `ES_VERSION=5.5 npm test`, things are all good. I am not sure if we should integrate this into our test file, or point it out at somewhere in docs. 