### PR TITLE
Add support for $exists and $missing queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,35 +121,21 @@ query: {
 
 ### $exists
 
-[Term level query `exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents that have at least one non-null value in the original field. The value can be an object or an array (not analyzed). 
+[Term level query `exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents that have at least one non-null value in the original field (not analyzed). 
 
 ```js
 query: {
-  $exists: { field: 'phone' }
-}
-// or an array
-query: {
-  $exists: [
-    { field: 'phone' },
-    { field: 'address' }
-  ]
+  $exists: ['phone', 'address']
 }
 ```
 
 ### $missing
 
-The inverse of [`exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents missing the specified field. The value can be an object or an array (not analyzed).
+The inverse of [`exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents missing the specified field (not analyzed).
 
 ```js
 query: {
-  $missing: { field: 'phone' }
-}
-// or an array
-query: {
-  $missing: [
-  	{ field: 'phone' },
-  	{ field: 'address' }
-  ]
+  $missing: ['phone', 'address']
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,40 @@ query: {
 }
 ```
 
+### $exists
+
+[Term level query `exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents that have at least one non-null value in the original field. The value can be an object or an array (not analyzed). 
+
+```js
+query: {
+  $exists: { field: 'phone' }
+}
+// or an array
+query: {
+  $exists: [
+    { field: 'phone' },
+    { field: 'address' }
+  ]
+}
+```
+
+### $missing
+
+The inverse of [`exists`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html). Find all documents missing the specified field. The value can be an object or an array (not analyzed).
+
+```js
+query: {
+  $missing: { field: 'phone' }
+}
+// or an array
+query: {
+  $missing: [
+  	{ field: 'phone' },
+  	{ field: 'address' }
+  ]
+}
+```
+
 ### $match
 
 [Full text query `match`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html). Find all documents which have given given fields matching the specified value (analysed).

--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -22,6 +22,8 @@ const specialQueryHandlers = {
   $all: $all,
   $sqs: $sqs,
   $nested: $nested,
+  $exists: (...args) => $exists('must', ...args),
+  $missing: (...args) => $exists('must_not', ...args),
   $child: (...args) => $childOr$parent('$child', ...args),
   $parent: (...args) => $childOr$parent('$parent', ...args)
 };
@@ -149,6 +151,29 @@ function $nested (value, esQuery) {
       }
     }
   });
+
+  return esQuery;
+}
+
+function $exists (clause, value, esQuery) {
+  let values;
+  let type = getType(value);
+
+  if (value === null || value === undefined) {
+    return esQuery;
+  }
+
+  if (type !== 'array') {
+    value = [value];
+  }
+
+  values = value.map(val => {
+    validateType(val, `${clause}.exists`, 'object');
+    validateType(val.field, `${clause}.exists.field`, 'string');
+    return { exists: val };
+  });
+
+  esQuery[clause] = (esQuery[clause] || []).concat(values);
 
   return esQuery;
 }

--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -157,20 +157,16 @@ function $nested (value, esQuery) {
 
 function $exists (clause, value, esQuery) {
   let values;
-  let type = getType(value);
 
   if (value === null || value === undefined) {
     return esQuery;
   }
 
-  if (type !== 'array') {
-    value = [value];
-  }
+  validateType(value, `${clause}.exists`, 'array');
 
-  values = value.map(val => {
-    validateType(val, `${clause}.exists`, 'object');
-    validateType(val.field, `${clause}.exists.field`, 'string');
-    return { exists: val };
+  values = value.map((val, i) => {
+    validateType(val, `${clause}.exists[${i}]`, 'string');
+    return { exists: { field: val } };
   });
 
   esQuery[clause] = (esQuery[clause] || []).concat(values);

--- a/test/utils/parse-query.js
+++ b/test/utils/parse-query.js
@@ -141,10 +141,10 @@ module.exports = function parseQueryTests () {
     });
 
     ['$exists', '$missing'].forEach(query => {
-      it(`should throw BadRequest if ${query} values are not objects with a (string)field property`, () => {
+      it(`should throw BadRequest if ${query} values are not arrays with (string)field property`, () => {
         expect(() => parseQuery({ [query]: 'foo' }, '_id')).to.throw(errors.BadRequest);
+        expect(() => parseQuery({ [query]: [1234] }, '_id')).to.throw(errors.BadRequest);
         expect(() => parseQuery({ [query]: { 'foo': 'bar' } }, '_id')).to.throw(errors.BadRequest);
-        expect(() => parseQuery({ [query]: ['foo'] }, '_id')).to.throw(errors.BadRequest);
         expect(() => parseQuery({ [query]: [{ 'foo': 'bar' }] }, '_id')).to.throw(errors.BadRequest);
       });
     });
@@ -532,27 +532,9 @@ module.exports = function parseQueryTests () {
     });
 
     [['$exists', 'must'], ['$missing', 'must_not']].forEach(([q, clause]) => {
-      it(`should return "${clause} exists" query for ${q}`, () => {
+      it(`should return "${clause}" query for ${q}`, () => {
         let query = {
-          [q]: { field: 'phone' }
-        };
-        let expectedResult = {
-          [clause]: [
-            {
-              exists: { field: 'phone' }
-            }
-          ]
-        };
-        expect(parseQuery(query, '_id')).to
-          .deep.equal(expectedResult);
-      });
-
-      it(`${q} query can handle an array of values`, () => {
-        let query = {
-          [q]: [
-            { field: 'phone' },
-            { field: 'address' }
-          ]
+          [q]: ['phone', 'address']
         };
         let expectedResult = {
           [clause]: [
@@ -588,8 +570,8 @@ module.exports = function parseQueryTests () {
           { tags: 'javascript' },
           { tags: 'legend' }
         ],
-        $exists: { field: 'phone' },
-        $missing: { field: 'address' }
+        $exists: ['phone'],
+        $missing: ['address']
       };
       let expectedResult = {
         should: [

--- a/test/utils/parse-query.js
+++ b/test/utils/parse-query.js
@@ -140,6 +140,15 @@ module.exports = function parseQueryTests () {
       expect(() => parseQuery({ age: () => {} }, '_id')).to.throw(errors.BadRequest);
     });
 
+    ['$exists', '$missing'].forEach(query => {
+      it(`should throw BadRequest if ${query} values are not objects with a (string)field property`, () => {
+        expect(() => parseQuery({ [query]: 'foo' }, '_id')).to.throw(errors.BadRequest);
+        expect(() => parseQuery({ [query]: { 'foo': 'bar' } }, '_id')).to.throw(errors.BadRequest);
+        expect(() => parseQuery({ [query]: ['foo'] }, '_id')).to.throw(errors.BadRequest);
+        expect(() => parseQuery({ [query]: [{ 'foo': 'bar' }] }, '_id')).to.throw(errors.BadRequest);
+      });
+    });
+
     it('should return term query for each primitive param', () => {
       let query = {
         user: 'doug',
@@ -522,6 +531,44 @@ module.exports = function parseQueryTests () {
         .deep.equal(expectedResult);
     });
 
+    [['$exists', 'must'], ['$missing', 'must_not']].forEach(([q, clause]) => {
+      it(`should return "${clause} exists" query for ${q}`, () => {
+        let query = {
+          [q]: { field: 'phone' }
+        };
+        let expectedResult = {
+          [clause]: [
+            {
+              exists: { field: 'phone' }
+            }
+          ]
+        };
+        expect(parseQuery(query, '_id')).to
+          .deep.equal(expectedResult);
+      });
+
+      it(`${q} query can handle an array of values`, () => {
+        let query = {
+          [q]: [
+            { field: 'phone' },
+            { field: 'address' }
+          ]
+        };
+        let expectedResult = {
+          [clause]: [
+            {
+              exists: { field: 'phone' }
+            },
+            {
+              exists: { field: 'address' }
+            }
+          ]
+        };
+        expect(parseQuery(query, '_id')).to
+          .deep.equal(expectedResult);
+      });
+    });
+
     it('should return all types of queries together', () => {
       let query = {
         $or: [
@@ -540,7 +587,9 @@ module.exports = function parseQueryTests () {
         $and: [
           { tags: 'javascript' },
           { tags: 'legend' }
-        ]
+        ],
+        $exists: { field: 'phone' },
+        $missing: { field: 'address' }
       };
       let expectedResult = {
         should: [
@@ -585,7 +634,8 @@ module.exports = function parseQueryTests () {
           { term: { tags: 'legend' } }
         ],
         must_not: [
-          { terms: { country: [ 'us', 'pl', 'ae' ] } }
+          { terms: { country: [ 'us', 'pl', 'ae' ] } },
+          { exists: { field: 'address' } }
         ],
         must: [
           { match: { bio: 'javascript' } },
@@ -625,7 +675,8 @@ module.exports = function parseQueryTests () {
                 }
               }
             }
-          }
+          },
+          { exists: { field: 'phone' } }
         ]
       };
 


### PR DESCRIPTION
I needed this for a project. Hope it can make it in. Here are the docs on the `$exists` query (scroll to bottom for the "missing" query).

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html