### PR TITLE
fix(package) update dependecies

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -2,16 +2,19 @@
 
 const feathersFilter = require('@feathersjs/commons').filterQuery;
 
-const { parseQuery } = require('./parse-query');
+const { parseQuery, operators } = require('./parse-query');
 const {
   removeProps,
   getDocDescriptor,
   getCompatVersion,
   getCompatProp
 } = require('./core');
+const esOperators = operators.filter(operator =>
+  feathersFilter.OPERATORS.indexOf(operator) === -1
+);
 
 function filter (query = {}, paginate = {}) {
-  let result = feathersFilter(query, paginate);
+  let result = feathersFilter(query, { paginate, operators: esOperators });
 
   if (result.filters.$skip === undefined || isNaN(result.filters.$skip)) {
     result.filters.$skip = 0;

--- a/lib/utils/parse-query.js
+++ b/lib/utils/parse-query.js
@@ -28,6 +28,22 @@ const specialQueryHandlers = {
   $parent: (...args) => $childOr$parent('$parent', ...args)
 };
 
+// The complete list of operators implemented by the adapter.
+// It's main purpose is to whitelist the non-standard operators
+// when we call `filterQuery` from @feathersjs/commons.
+const operators = [
+  ...Object.keys(queryCriteriaMap),
+  ...Object.keys(specialQueryHandlers),
+  // Used by $sqs:
+  '$query',
+  '$fields',
+  '$operator',
+  // Used by $child, $parent:
+  '$type',
+  // Used by $nested:
+  '$path'
+];
+
 function $or (value, esQuery, idProp) {
   validateType(value, '$or', 'array');
 
@@ -239,4 +255,4 @@ function parseQuery (query, idProp) {
   return bool;
 }
 
-module.exports = { parseQuery };
+module.exports = { parseQuery, operators };

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,26 +68,16 @@
       }
     },
     "@feathersjs/commons": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.0.tgz",
-      "integrity": "sha512-21/E+KpFJO32fK8snn9kVCWi7R3C2CEPUsuxgYg61mKqydXBvo0lDzMfhp//o4pu9rdZrvNSGyb32Gvi3eK3OA=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-wo2boFwbKqm53h/Wv2F+ggiTxSFOPaCupa6VHujJle/RZrox5On6zbaoO0B1yFZbj1tCJ6kT2IDpFg9StHL0oA=="
     },
     "@feathersjs/errors": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.2.2.tgz",
-      "integrity": "sha512-j2SiZBUimcUAFXGnmiByQKV+8/OehnJFGP5wT3XKjU6nyiLft6Av5ti1/sRV+ji2Tu80H6YVfhIoVG8ndEpBnA==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@feathersjs/errors/-/errors-3.3.4.tgz",
+      "integrity": "sha512-yA/HXSWgLiK4ngFslCHxcvnt+gek4fUhJcwpix9Z1jpTnCWW5WqtNxUfUqE1Fj8wKq0Y6VPSaQtE+RZcgryDQQ==",
       "requires": {
-        "debug": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "debug": "^4.0.0"
       }
     },
     "@feathersjs/express": {
@@ -103,6 +93,12 @@
         "uberproto": "^1.2.0"
       },
       "dependencies": {
+        "@feathersjs/commons": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.4.tgz",
+          "integrity": "sha512-ZPpzyZA3CPfoa9AuFv3BJUI/ubzaaXixp8T/pqeMFPT6DOaU/6oF7lz1RxwimzfJNna4gy/HByt0EoLSI3BKWg==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -132,6 +128,12 @@
         "uberproto": "^1.2.0"
       },
       "dependencies": {
+        "@feathersjs/commons": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.4.tgz",
+          "integrity": "sha512-ZPpzyZA3CPfoa9AuFv3BJUI/ubzaaXixp8T/pqeMFPT6DOaU/6oF7lz1RxwimzfJNna4gy/HByt0EoLSI3BKWg==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -184,6 +186,12 @@
         "radix-router": "^3.0.1"
       },
       "dependencies": {
+        "@feathersjs/commons": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/@feathersjs/commons/-/commons-1.4.4.tgz",
+          "integrity": "sha512-ZPpzyZA3CPfoa9AuFv3BJUI/ubzaaXixp8T/pqeMFPT6DOaU/6oF7lz1RxwimzfJNna4gy/HByt0EoLSI3BKWg==",
+          "dev": true
+        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -294,7 +302,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2381,8 +2388,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "optional": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2728,7 +2734,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2813,8 +2818,7 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -3176,7 +3180,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -4207,8 +4210,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -5768,8 +5770,7 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "lib": "lib"
   },
   "dependencies": {
-    "@feathersjs/commons": "^1.3.0",
-    "@feathersjs/errors": "^3.2.0",
+    "@feathersjs/commons": "^3.0.1",
+    "@feathersjs/errors": "^3.3.4",
     "debug": "^4.0.0",
     "uberproto": "^2.0.0"
   },

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -21,8 +21,7 @@ describe('Elasticsearch utils', () => {
           $sort: undefined,
           $limit: undefined,
           $skip: 0,
-          $select: true,
-          $populate: undefined
+          $select: true
         },
         query: {}
       };
@@ -78,7 +77,7 @@ describe('Elasticsearch utils', () => {
 
     [ 'some random string', 23, null, [], {} ]
       .forEach(select => {
-        it(`should pass through $select if it ${typeof select} e.g. '${JSON.stringify(select)}'`, () => {
+        it(`should pass through $select if it is ${typeof select} e.g. '${JSON.stringify(select)}'`, () => {
           expectedResult.filters.$select = select;
 
           expect(filter({ $select: select })).to


### PR DESCRIPTION
### Summary

Greenkeeper's PR with @feathersjs/commons upgrade failed, because the `filterQuery` function contained in that package has change it's behaviour. Now it requires a whitelist of non-standard operators, otherwise they get stripped off from the payload.

I have fixed the way it's called in the service and now it's all gravy.