### PR TITLE
Consider upsert param when setting the method in create-bulk

### DIFF
--- a/lib/core/create-bulk/6.0.js
+++ b/lib/core/create-bulk/6.0.js
@@ -8,12 +8,12 @@ const createBulkCore = require('./core');
 // https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-bulk
 // reduce() here is acting as a map() mapping one element into two.
 
-function getBulkCreateParams (service, data) {
+function getBulkCreateParams (service, data, params) {
   return Object.assign(
     {
       body: data.reduce((result, item) => {
         let { id, parent, routing, join, doc } = getDocDescriptor(service, item);
-        let method = id !== undefined ? 'create' : 'index';
+        let method = id !== undefined && !params.upsert ? 'create' : 'index';
 
         if (join) {
           doc[service.join] = {

--- a/lib/core/create-bulk/core.js
+++ b/lib/core/create-bulk/core.js
@@ -9,7 +9,7 @@ function createBulkCore (
   params,
   { getBulkCreateParams }
 ) {
-  let bulkCreateParams = getBulkCreateParams(service, data);
+  let bulkCreateParams = getBulkCreateParams(service, data, params);
 
   return service.Model.bulk(bulkCreateParams)
     .then(results => {


### PR DESCRIPTION
### Summary

Fixes an issue where using upsert with a bulk create request causing 409 errors

alyrik mentioned the same problem here:
https://github.com/feathersjs-ecosystem/feathers-elasticsearch/issues/75
