### PR TITLE
Add support for elasticsearch 7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,24 @@ dist: trusty
 sudo: required
 language: node_js
 node_js: node
+services:
+  - docker
 env:
-  - ES_VERSION=2.4.3 ES_DOWNLOAD=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.3/elasticsearch-2.4.3.deb
-  - ES_VERSION=5.6.7 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.7.deb
-  - ES_VERSION=6.0.1 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.1.deb
-  - ES_VERSION=6.1.4 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.1.4.deb
-  - ES_VERSION=6.2.4 ES_DOWNLOAD=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.4.deb
+  - ES_VERSION=2.4.3
+  - ES_VERSION=5.6.7
+  - ES_VERSION=6.6.2
+  - ES_VERSION=6.7.2
+  - ES_VERSION=6.8.0
 addons:
   code_climate:
     repo_token: 'f7898d1d1ca2b76715bc35cc3ba880b35e3fbdc07c3aeb27ca98eecb5e5c064d'
 notifications:
   email: false
-install: npm install
 before_install:
   - sudo sysctl vm.max_map_count=262144
-  - curl -O ${ES_DOWNLOAD} && sudo dpkg -i --force-confnew elasticsearch-${ES_VERSION}.deb && sudo service elasticsearch restart
+  - docker pull elasticsearch:${ES_VERSION}
+  - docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:${ES_VERSION}
+install:
+  - npm install
 before_script:
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - ES_VERSION=6.6.2
   - ES_VERSION=6.7.2
   - ES_VERSION=6.8.0
+  - ES_VERSION=7.0.1
+  - ES_VERSION=7.1.1
 addons:
   code_climate:
     repo_token: 'f7898d1d1ca2b76715bc35cc3ba880b35e3fbdc07c3aeb27ca98eecb5e5c064d'
@@ -18,7 +20,7 @@ notifications:
 before_install:
   - sudo sysctl vm.max_map_count=262144
   - docker pull elasticsearch:${ES_VERSION}
-  - docker run -d -p 9200:9200 -p 9300:9300 elasticsearch:${ES_VERSION}
+  - docker run -d -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" elasticsearch:${ES_VERSION}
 install:
   - npm install
 before_script:

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ docService.remove(
 
 ## Supported Elasticsearch versions
 
-feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 6.0, 6.1 and 6.2. Please note, even though the lowest version supported is 2.4, that does not mean it wouldn't work fine on anything lower than 2.4.
+feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.6, 6.6, 6.7 and 6.8. Please note, even though the lowest version supported is 2.4, that does not mean it wouldn't work fine on anything lower than 2.4.
 
 ## Quirks
 
@@ -454,6 +454,28 @@ postService.update(123, {
   upsert: true
 })
 
+```
+
+## Contributing
+
+If you find a bug or something to improve we will be happy to see your PR!
+
+When adding a new feature, please make sure you write tests for it with decent coverage as well.
+
+### Running tests locally
+
+When you run the test locally, you need to set the Elasticsearch version you are testing against in an environmental variable `ES_VERSION` to tell the tests which schema it should set up. The value from this variable will be also used to determine the API version for the Elasticsearch client and the tested service.
+
+If you want to all tests:
+
+```bash
+ES_VERSION=6.7.2 npm t
+```
+
+When you just want to run coverage:
+
+```bash
+ES_VERSION=6.7.2 npm run coverage
 ```
 
 ## Born out of need

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ docService.remove(
 
 ## Supported Elasticsearch versions
 
-feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.6, 6.6, 6.7 and 6.8. Please note, even though the lowest version supported is 2.4, that does not mean it wouldn't work fine on anything lower than 2.4.
+feathers-elasticsearch is currently tested on Elasticsearch 2.4, 5.6, 6.6, 6.7, 6.8, 7.0 and 7.1 Please note, even though the lowest version supported is 2.4, that does not mean it wouldn't work fine on anything lower than 2.4.
 
 ## Quirks
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following options can be passed when creating a new Elasticsearch service:
 - `routing` (default: '_routing') [optional] - The routing property, which is used to pass document's routing parameter.
 - `join` (default: undefined) [optional] - Elasticsearch 6.0+ specific. The name of the [join field](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/parent-join.html) defined in the mapping type used by the service. It is required for parent-child relationship features (e.g. setting a parent, `$child` and `$parent` queries) to work.
 - `meta` (default: '_meta') [optional] - The meta property of your documents in this service. The meta field is an object containing elasticsearch specific information, e.g. `_score`, `_type`, `_index`, `_parent`, `_routing` and so forth. It will be stripped off from the documents passed to the service.
+- `whitelist` (default: `['$prefix', '$wildcard', '$regexp', '$exists', '$missing', '$all', '$match', '$phrase', '$phrase_prefix', '$and', '$sqs', '$child', '$parent', '$nested', '$fields', '$path', '$type', '$query', '$operator']`) [optional] - The list of additional non-standard query parameters to allow, by default populated with all Elasticsearch specific ones. You can override, for example in order to restrict access to some queries (see the [options documentation](https://docs.feathersjs.com/api/databases/common.html#serviceoptions)).
 
 ## Complete Example
 

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -13,8 +13,12 @@ function mapFind (results, idProp, metaProp, joinProp, filters, hasPagination) {
     .map(result => mapGet(result, idProp, metaProp, joinProp));
 
   if (hasPagination) {
+    const total = typeof results.hits.total === 'object'
+      ? results.hits.total.value
+      : results.hits.total;
+
     return {
-      total: results.hits.total,
+      total,
       skip: filters.$skip,
       limit: filters.$limit,
       data

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,7 +361,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -583,7 +583,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -721,7 +721,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
       "dev": true
     },
@@ -1686,7 +1686,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -1988,7 +1988,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -2524,7 +2524,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2614,13 +2614,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2699,7 +2699,7 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
@@ -2957,7 +2957,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -3072,7 +3072,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3351,7 +3351,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -3955,7 +3955,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -4014,7 +4014,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -4041,7 +4041,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
@@ -4111,7 +4111,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@feathersjs/feathers": "^3.3.0",
     "@feathersjs/socketio": "^3.2.8",
     "chai": "^4.2.0",
-    "elasticsearch": "^15.2.0",
+    "elasticsearch": "^15.5.0",
     "eslint": "^6.0.0",
     "mocha": "^6.0.0",
     "nyc": "^14.0.0",

--- a/test-utils/schema-2.4.js
+++ b/test-utils/schema-2.4.js
@@ -12,7 +12,8 @@ const schema = [
               properties: {
                 street: { type: 'string', index: 'not_analyzed' }
               }
-            }
+            },
+            phone: { type: 'string', index: 'not_analyzed' }
           }
         },
         aka: {

--- a/test-utils/schema-5.0.js
+++ b/test-utils/schema-5.0.js
@@ -12,7 +12,8 @@ const schema = [
               properties: {
                 street: { type: 'keyword' }
               }
-            }
+            },
+            phone: { type: 'keyword' }
           }
         },
         aka: {

--- a/test-utils/schema-6.0.js
+++ b/test-utils/schema-6.0.js
@@ -13,6 +13,7 @@ const schema = [
                 street: { type: 'keyword' }
               }
             },
+            phone: { type: 'keyword' },
             aka: {
               type: 'join',
               relations: {

--- a/test-utils/schema-7.0.js
+++ b/test-utils/schema-7.0.js
@@ -1,0 +1,38 @@
+const schema = [
+  {
+    index: 'test-people',
+    body: {
+      mappings: {
+        properties: {
+          name: { type: 'keyword' },
+          tags: { type: 'keyword' },
+          addresses: {
+            type: 'nested',
+            properties: {
+              street: { type: 'keyword' }
+            }
+          },
+          phone: { type: 'keyword' },
+          aka: {
+            type: 'join',
+            relations: {
+              real: 'alias'
+            }
+          }
+        }
+      }
+    }
+  },
+  {
+    index: 'test-todos',
+    body: {
+      mappings: {
+        properties: {
+          text: { type: 'keyword' }
+        }
+      }
+    }
+  }
+];
+
+module.exports = schema;

--- a/test-utils/test-db.js
+++ b/test-utils/test-db.js
@@ -3,7 +3,7 @@ const { getCompatVersion, getCompatProp } = require('../lib/utils/core');
 
 let apiVersion = null;
 let client = null;
-let schemaVersions = ['2.4', '5.0', '6.0'];
+let schemaVersions = ['2.4', '5.0', '6.0', '7.0'];
 
 const compatVersion = getCompatVersion(schemaVersions, getApiVersion());
 const compatSchema = require(`./schema-${compatVersion}`);
@@ -19,6 +19,12 @@ function getServiceConfig (serviceName) {
         ? 'test-people'
         : `test-${serviceName}`,
       type: 'doc'
+    },
+    '7.0': {
+      index: serviceName === 'aka'
+        ? 'test-people'
+        : `test-${serviceName}`,
+      type: '_doc'
     }
   };
 

--- a/test/core/find.js
+++ b/test/core/find.js
@@ -254,6 +254,39 @@ function find (app, serviceName, esVersion) {
             expect(results[0].name).to.equal('Bob');
           });
       });
+
+      it('can $exists', () => {
+        return app.service(serviceName)
+          .find({
+            query: {
+              $exists: ['phone']
+            }
+          })
+          .then(results => {
+            expect(results.length).to.equal(1);
+            expect(results[0].name).to.equal('Douglas');
+          });
+      });
+
+      it('can $missing', () => {
+        const expectedLength = getCompatProp({
+          '2.4': 2,
+          '6.0': 5
+        }, esVersion);
+
+        return app.service(serviceName)
+          .find({
+            query: {
+              $sort: { name: 1 },
+              $missing: ['phone']
+            }
+          })
+          .then(results => {
+            expect(results.length).to.equal(expectedLength);
+            expect(results[0].name).to.equal('Bob');
+            expect(results[1].name).to.equal('Moody');
+          });
+      });
     });
   });
 }

--- a/test/core/patch.js
+++ b/test/core/patch.js
@@ -136,7 +136,7 @@ function patch (app, serviceName, esVersion) {
           expect(results[0].name).to.equal('patched');
           expect(results[1].name).to.equal('patched');
 
-          app.service('aka').remove(
+          return app.service('aka').remove(
             null,
             { query: { name: 'patched' } }
           );

--- a/test/core/raw.js
+++ b/test/core/raw.js
@@ -38,7 +38,8 @@ function raw (app, serviceName, esVersion) {
     it('should show the mapping of index test', () => {
       const mappings = {
         '2.4': ['test.mappings.aka._parent.type', 'people'],
-        '6.0': ['test-people.mappings.doc.properties.aka.type', 'join']
+        '6.0': ['test-people.mappings.doc.properties.aka.type', 'join'],
+        '7.0': ['test-people.mappings.properties.aka.type', 'join']
       };
 
       return app.service('aka')

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,7 @@ describe('Elasticsearch Service', () => {
           bio: 'A legend',
           tags: ['javascript', 'legend', 'programmer'],
           addresses: [ { street: '3 The Road' }, { street: 'Coder Alley' } ],
+          phone: '0123455567',
           aka: 'real'
         }
       ]);
@@ -161,8 +162,8 @@ describe('Elasticsearch Service', () => {
       ]);
     });
 
-    after(() => {
-      app.service(serviceName).remove(null, { query: { $limit: 1000 } });
+    after(async () => {
+      await app.service(serviceName).remove(null, { query: { $limit: 1000 } });
     });
 
     coreTests.find(app, serviceName, esVersion);


### PR DESCRIPTION
### Summary
The focus of this PR is mostly on tests and docs, although there are a few other bits as well.

The main highlight is added support for the latest version of Elasticsearch - 7.1.x

- [Travis] Replaced elasticsearch deb package with a docker image of elasticsearch. It is simpler to run, no need to maintain the list of download files and the tests don't take any longer after the change.
- [Travis] Added tests for the highest three minors in the 6.x line and the highest two minors in the 7.x
- [Unit] Added missing tests for `$missing` and `$exists`
- [Service] Added support for 7.x line - the pagination needed to take into account that `total` in 7.x is return as an object rather than a number.
- [Docs] Added description of the `whitelist` option. Added "Contributing" section.
